### PR TITLE
Ready to be merged

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 pyinjector
 bs4
 pillow
+win10toast

--- a/ymu.py
+++ b/ymu.py
@@ -22,6 +22,7 @@ import os
 import psutil
 import re
 import requests
+import subprocess
 import webbrowser
 import win32api
 from bs4 import BeautifulSoup
@@ -127,6 +128,16 @@ DLLURL = "https://github.com/YimMenu/YimMenu/releases/download/nightly/YimMenu.d
 DLLDIR = ".\\ymu\\dll"
 LOCALDLL = ".\\ymu\\dll\\YimMenu.dll"
 
+LAUNCHERS = ["Launcher", # placeholder
+             "Steam", 
+             "Epic Games",
+             "Rockstar Games",
+            ]
+
+launcherVar = ctk.StringVar()
+
+def set_launcher(launcher:str):
+    launcherVar.set(launcher)
 
 # self update stuff
 
@@ -876,32 +887,45 @@ download_button.bind("<Enter>", hover_download_button)
 download_button.bind("<Leave>", nohover_download_button)
 
 
-# Inject-Tab
-def ff(rf, rx):
-    global gamePath # 🙈
-    for root, _, files in os.walk(rf):
-        for f in files:
-            result = rx.search(f)
-            if result:
-                gamePath = (os.path.join(root, f))
-                break
+# # Inject-Tab
+# def ff(rf, rx):
+#     global gamePath # 🙈
+#     for root, _, files in os.walk(rf):
+#         for f in files:
+#             result = rx.search(f)
+#             if result:
+#                 gamePath = (os.path.join(root, f))
+#                 break
 
-def findall(file_name) -> str:
-    regex = re.compile(file_name)
-    for drive in win32api.GetLogicalDriveStrings().split('\000')[:-1]:
-        ff(drive, regex)
+# def findall(file_name) -> str:
+#     regex = re.compile(file_name)
+#     for drive in win32api.GetLogicalDriveStrings().split('\000')[:-1]:
+#         ff(drive, regex)
+
+def get_launcher() -> str:
+    user_launcher = launcherVar.get()
+    if user_launcher == "Steam":
+        return 'cmd /c start steam://run/271590' # works perfectly
+    elif user_launcher == "Rockstar Games":
+        print("It seems there is no command for rockstar games launcher so we will have to figure out something else")
+    elif user_launcher == "Epic Games":
+        return 'cmd /c start com.epicgames.launcher://apps/9d2d0eb64d5c44529cece33fe2a46482?action=launch&silent=true' ## needs double checking. the command is correct but the way it will be executed is what I'm not sure about
+    else:
+        print("Not Provided") ## probably open a filedialog and grab the path?
 
 def start_gta():
     find_gta_process()
     if not is_running:
         try:
-            inject_progress_label.configure(text="Please wait while YMU attempts to find your game...")
+            inject_progress_label.configure(text="Please wait while YMU attempts to start your game...")
             dummy_progress(injection_progressbar)
             start_gta_button.configure(state = 'disabled')
-            findall('PlayGTAV.exe')
-            inject_progress_label.configure(text=f'Found GTA5 under\n{gamePath}.\nYour game will start in a few seconds...')
+            run_cmd = get_launcher() # run dmc's cousin
+            # findall('PlayGTAV.exe')
+            # inject_progress_label.configure(text=f'Found GTA5 under\n{gamePath}.\nYour game will start in a few seconds...')
             reset_inject_progress_label(3)
-            os.startfile(gamePath)
+            # os.startfile(gamePath)
+            subprocess.run(run_cmd)
             start_gta_button.configure(state = 'normal')
 
         except Exception as e:
@@ -1039,6 +1063,25 @@ buttons_frame = ctk.CTkFrame(
 buttons_frame.pack(pady=0, padx=0, expand=True, fill=None)
 buttons_frame.bind("<Enter>", hover_buttons_frame)
 
+
+launchers_menu = ctk.CTkOptionMenu(
+                    master=buttons_frame,
+                    values=LAUNCHERS,
+                    command=set_launcher,
+                    fg_color=BG_COLOR_D,
+                    text_color=WHITE,
+                    bg_color="transparent",
+                    button_color=BG_COLOR_D,
+                    button_hover_color=GREEN_D,
+                    font=SMALL_BOLD_FONT,
+                    dynamic_resizing=False,
+                    dropdown_fg_color=BG_COLOR_D,
+                    dropdown_font=SMALL_FONT,
+                    dropdown_hover_color=BG_COLOR,
+                    dropdown_text_color=WHITE,
+                    corner_radius=8,
+                    width=120,
+                    ).pack(pady=0, padx=0, expand=False, fill=None)
 
 def hover_start_gta_button(e):
     start_gta_button.configure(text_color=GREEN, fg_color=GREEN_B)

--- a/ymu.py
+++ b/ymu.py
@@ -277,7 +277,7 @@ def get_remote_sha256():
 
 # self explanatory
 def check_if_dll_is_downloaded():
-    # while True:
+    while True:
         if os.path.exists(DLLDIR):
             if os.path.isfile(LOCALDLL):
                 LOCAL_SHA = get_local_sha256()

--- a/ymu.py
+++ b/ymu.py
@@ -4,16 +4,23 @@ import sys
 
 notif = ToastNotifier()
 
-# check if YMU is already running. If it is, bring it to foreground and exit (moving this above the rest of the imports makes it much faster).
-ymu_window = win32gui.FindWindow(None, 'YMU - YimMenuUpdater')
-if ymu_window != 0:
-    win32gui.SetForegroundWindow(ymu_window)
-    try:
-        notif.show_toast('YMU', 'The program is already running!', duration = 10)
-    except TypeError: #win10Toast has a bug and will always raise a TypeError. It's not a big deal so it's safe to just simply ignore it.
-        pass
-    sys.exit(0)
+def resource_path(relative_path):
+    base_path = getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(base_path, relative_path)
 
+if getattr(sys, 'frozen', False):
+    # check if YMU is already running. If it is, bring it to foreground and exit (moving this above the rest of the imports makes it much faster).
+    ymu_window = win32gui.FindWindow(None, 'YMU - YimMenuUpdater')
+    if ymu_window is not None and ymu_window != 0:
+        win32gui.SetForegroundWindow(ymu_window)
+        # try:
+        #     notif.show_toast('YMU', 'The program is already running!', duration = 10, icon_path = (resource_path("assets\\icon\\ymu.ico")))
+        # except TypeError: #win10Toast has a bug and will always raise a TypeError. It's not a big deal so it's safe to just simply ignore it.
+        #     pass
+        sys.exit(0)
+    else:
+        # if YMU is not already running, show a splash screen during the loading time.
+        import pyi_splash
 
 # Libraries YMU depends on
 import customtkinter as ctk
@@ -32,16 +39,6 @@ from PIL import Image
 from time import sleep
 import json
 from configparser import ConfigParser
-
-
-# show a splash screen when the executable is loading.
-if getattr(sys, 'frozen', False):
-    import pyi_splash
-
-def resource_path(relative_path):
-    # Since we're using --onefile command, PyInstaller will create a temp folder and store the path in _MEIPASS
-    base_path = getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(__file__)))
-    return os.path.join(base_path, relative_path)
 
 # YMU Appearance
 CONFIGPATH = "ymu\\config.ini"
@@ -359,7 +356,7 @@ def refresh_download_button():
         )
         progressbar.set(0)
         try:
-            notif.show_toast('YMU', 'A new YimMenu release is out! Get the latest version from the "Update" tab.', duration = 15)
+            notif.show_toast('YMU', f'A new YimMenu release is out! Get the latest version from the {check_if_dll_is_downloaded()} tab.', duration = 15, icon_path = (resource_path("assets\\icon\\ymu.ico")))
         except TypeError:
             pass
 

--- a/ymu.py
+++ b/ymu.py
@@ -883,22 +883,9 @@ download_button.bind("<Enter>", hover_download_button)
 download_button.bind("<Leave>", nohover_download_button)
 
 
-# # Inject-Tab
-# def ff(rf, rx):
-#     global gamePath # 🙈
-#     for root, _, files in os.walk(rf):
-#         for f in files:
-#             result = rx.search(f)
-#             if result:
-#                 gamePath = (os.path.join(root, f))
-#                 break
-
-# def findall(file_name) -> str:
-#     regex = re.compile(file_name)
-#     for drive in win32api.GetLogicalDriveStrings().split('\000')[:-1]:
-#         ff(drive, regex)
-
+# Inject-Tab
 def get_launcher() -> str:
+    global user_launcher
     user_launcher = launcherVar.get()
     if user_launcher == "Steam":
         return 'cmd /c start steam://run/271590' # works perfectly
@@ -907,7 +894,7 @@ def get_launcher() -> str:
     elif user_launcher == "Epic Games":
         return 'cmd /c start com.epicgames.launcher://apps/9d2d0eb64d5c44529cece33fe2a46482?action=launch&silent=true'
     else:
-        return 'shitstick'
+        return '_none'
     
 def get_rgl_path() -> str:
     regkey = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r'SOFTWARE\\WOW6432Node\\Rockstar Games\\', 0, winreg.KEY_READ)
@@ -922,18 +909,25 @@ def start_gta():
     find_gta_process()
     if not is_running:
         try:
-            inject_progress_label.configure(text="Please wait while YMU attempts to launch your game...")
-            dummy_progress(injection_progressbar)
-            start_gta_button.configure(state = 'disabled')
             run_cmd = get_launcher() # run dmc's cousin
             if run_cmd == "rgs":
+                inject_progress_label.configure(text="Please wait while YMU attempts to launch your game through\nRockstar Games Launcher...")
+                dummy_progress(injection_progressbar)
+                start_gta_button.configure(state = 'disabled')
                 rgl_path = get_rgl_path()
                 os.startfile(rgl_path + 'PlayGTAV.exe')
-            elif run_cmd == 'shitstick':
-                print('wenn das leben dir zitronen gibt 🍋')
+                sleep(3)
+            elif run_cmd == '_none':
+                inject_progress_label.configure(text="Please select your lancher from the dropdown list!", text_color=RED)
+                start_gta_button.configure(state = 'disabled')
             else:
+                inject_progress_label.configure(text=f"Please wait while YMU attempts to launch your game through\n{user_launcher}...")
+                dummy_progress(injection_progressbar)
+                start_gta_button.configure(state = 'disabled')
                 subprocess.run(run_cmd)
-            reset_inject_progress_label(3)
+                sleep(3)
+
+            reset_inject_progress_label(5)
             start_gta_button.configure(state = 'normal')
 
         except Exception as e:


### PR DESCRIPTION
- Added a check on init to prevent running multiple instances of YMU.
- Added a Windows 10/11-style notification if an update for YimMenu was found.

### Experimental code for starting GTA5 <- **THIS NEEDS TESTING BEFORE MERGING THE PR.**
~1. This process is **VERY** slow.
2. It started the game for me everytime without asking for Admin rights. There is a chance that it may not behave the same on your machine.
3. If it does indeed behave the same on your end then we can further improve it by saving the found path in the config file and changing the code to only search for the executable if there is no saved path in the config. That way the user won't have to wait 69 years each time they want to start the game from YMU.~

Scratch that. The whole idea was stupid anyway.
The OptionMenu with launchers is the way to go in my opinion. This test PR includes code that successfully launches Steam and GTA 5 in a few seconds without asking for elevated permissions.
The code for launching Epic Games GTA is also there but I have no way of testing it.
If the EGS method also works, and you agree that it's better than the previous methods, we'll move on to figuring out Rockstar Games Launcher and other case scenarios.

### Update:
 - [x] All three launcher options work.